### PR TITLE
Fix photo aspect ratio issue

### DIFF
--- a/JPSImagePickerController/JPSImagePickerController.m
+++ b/JPSImagePickerController/JPSImagePickerController.m
@@ -266,6 +266,7 @@
 - (NSBlockOperation *)captureOperation {
     NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
         self.session = [[AVCaptureSession alloc] init];
+        self.session.sessionPreset = AVCaptureSessionPresetPhoto;
         AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
         NSError *error = nil;
         


### PR DESCRIPTION
by setting `sessionPreset` to `AVCaptureSessionPresetPhoto` right after self.session is been initiated.

This pull request fixed the issue #3 .